### PR TITLE
Center on a map pin if included in URL fragment

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -38,6 +38,7 @@ class MapController {
     ];
     this.map.setMaxBounds(bounds);
     this.map.fitBounds(bounds);
+    loader.then(() => this.focus_named_marker());
   }
 
   on_theme_changed(event) {
@@ -48,6 +49,20 @@ class MapController {
     this.map.removeLayer(old_vec);
     this.layer_control.remove();
     this.setup_controls(this.osm_layer, vec);
+  }
+
+  focus_named_marker() {
+    let fragment = document.location.hash;
+    if (!fragment) return;
+    fragment = decodeURIComponent(fragment.slice(1)).toLocaleLowerCase().replace('_', ' ')
+    this.map.eachLayer((layer) => {
+      if (!layer.feature) return;
+      // Has a feature, so is some geometry object
+      const title = layer.feature.properties.name.toLocaleLowerCase()
+      if (fragment != title) return;
+      this.map.flyTo(layer.getLatLng(), 9);
+      layer.openPopup();
+    })
   }
 
   loadOSMLayer() {

--- a/static/map.js
+++ b/static/map.js
@@ -31,7 +31,7 @@ class MapController {
       zoomDelta: 0.25,
     });
     this.setup_layers();
-    this.load_objects(objects_url);
+    const loader = this.load_objects(objects_url);
     const bounds = [
       [48.986, 13.99],
       [55.228, 24.161],
@@ -86,7 +86,7 @@ class MapController {
   }
 
   load_objects(url) {
-    fetch(url)
+    return fetch(url)
       .then((response) => response.json())
       .then((data) => this.add_features(data));
   }

--- a/static/map.js
+++ b/static/map.js
@@ -60,7 +60,7 @@ class MapController {
       // Has a feature, so is some geometry object
       const title = layer.feature.properties.name.toLocaleLowerCase()
       if (fragment != title) return;
-      this.map.flyTo(layer.getLatLng(), 10);
+      this.map.flyTo(layer.getLatLng(), 13);
       layer.openPopup();
     })
   }

--- a/static/map.js
+++ b/static/map.js
@@ -60,7 +60,7 @@ class MapController {
       // Has a feature, so is some geometry object
       const title = layer.feature.properties.name.toLocaleLowerCase()
       if (fragment != title) return;
-      this.map.flyTo(layer.getLatLng(), 9);
+      this.map.flyTo(layer.getLatLng(), 10);
       layer.openPopup();
     })
   }


### PR DESCRIPTION
Testing: https://fly-to-fragment-carto.k33rni.workers.dev/#Klub%20Pod%20Palm%C4%85

in general, craft a URL where the fragment matches a marker's name (if GeoJSON) or page title (if venue page), and open it in a new window. Changing it in an already open window is not supported, and not important for now.